### PR TITLE
Artist service mock

### DIFF
--- a/rococo-auth/src/main/kotlin/guru/qa/rococo/config/CookieAccessTokenResponseHandler.kt
+++ b/rococo-auth/src/main/kotlin/guru/qa/rococo/config/CookieAccessTokenResponseHandler.kt
@@ -1,0 +1,56 @@
+package guru.qa.rococo.config
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AccessTokenAuthenticationToken
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.http.MediaType
+import org.springframework.http.server.ServletServerHttpResponse
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter
+import java.time.Duration
+import java.time.Instant
+
+class CookieAccessTokenResponseHandler : AuthenticationSuccessHandler {
+    private val writer = OAuth2AccessTokenResponseHttpMessageConverter()
+
+    override fun onAuthenticationSuccess(req: HttpServletRequest, res: HttpServletResponse, auth: Authentication) {
+        val at = auth as OAuth2AccessTokenAuthenticationToken
+
+        val access = at.accessToken.tokenValue
+        val expires = at.accessToken.expiresAt?.let { Duration.between(Instant.now(), it).seconds } ?: 0
+
+        // 1) Кладём access_token в HttpOnly cookie (авто-уходит на 3000/8080/9000)
+        val accessCookie = ResponseCookie.from("rococo_access", access)
+            .httpOnly(true)
+            .secure(false)              // для http на локалке; на https поставь true
+            .path("/")
+            .sameSite("Lax")            // порты не мешают, это same-site
+            .maxAge(expires)
+            .build()
+        res.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString())
+
+        // (опц.) можно положить id_token в НЕ HttpOnly, если когда-то пригодится фронту:
+        (at.additionalParameters["id_token"] as? String)?.let { idt ->
+            val idCookie = ResponseCookie.from("rococo_id", idt)
+                .httpOnly(false).secure(false).path("/").sameSite("Lax").maxAge(expires).build()
+            res.addHeader(HttpHeaders.SET_COOKIE, idCookie.toString())
+        }
+
+        // 2) Вернём стандартный JSON, как обычно
+        val resp = OAuth2AccessTokenResponse.withToken(access)
+            .tokenType(OAuth2AccessToken.TokenType.BEARER)
+            .scopes(at.accessToken.scopes)
+            .expiresIn(expires)
+            .refreshToken(at.refreshToken?.tokenValue)
+            .additionalParameters(at.additionalParameters)
+            .build()
+
+        res.contentType = MediaType.APPLICATION_JSON_VALUE
+        writer.write(resp, MediaType.APPLICATION_JSON, ServletServerHttpResponse(res))
+    }
+}

--- a/rococo-auth/src/main/kotlin/guru/qa/rococo/config/SecurityConfig.kt
+++ b/rococo-auth/src/main/kotlin/guru/qa/rococo/config/SecurityConfig.kt
@@ -34,7 +34,8 @@ class SecurityConfig(
         http
             .authorizeHttpRequests { auth ->
                 auth
-                    .requestMatchers("/login", "/register", "/css/**", "/js/**", "/styles/**", "/images/**", "/favicon.ico").permitAll()
+                    .requestMatchers("/.well-known/**").permitAll()
+                    .requestMatchers("/login","/error", "/register", "/css/**", "/js/**", "/styles/**", "/images/**", "/favicon.ico").permitAll()
                     .anyRequest().authenticated()
             }
             .formLogin { it.loginPage("/login").permitAll() }

--- a/rococo-auth/src/main/kotlin/guru/qa/rococo/controller/RegisterController.kt
+++ b/rococo-auth/src/main/kotlin/guru/qa/rococo/controller/RegisterController.kt
@@ -2,7 +2,6 @@ package guru.qa.rococo.controller
 
 import guru.qa.rococo.service.RegistrationModel
 import guru.qa.rococo.service.UserService
-import jakarta.validation.Valid
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.validation.BindingResult
@@ -24,7 +23,7 @@ class RegisterController(
 
     @PostMapping("/register")
     fun register(
-        @ModelAttribute("registrationModel") @Valid form: RegistrationModel,
+        @ModelAttribute("registrationModel") form: RegistrationModel,
         bindingResult: BindingResult,
         model: Model
     ): String {

--- a/rococo-auth/src/main/resources/application.yaml
+++ b/rococo-auth/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ server:
   port: 9000
   error:
     whitelabel:
-      enabled: false
+      enabled: true
     path: /error
 
 spring:

--- a/rococo-client/src/lib/api/apiClient.ts
+++ b/rococo-client/src/lib/api/apiClient.ts
@@ -159,7 +159,7 @@ const commonFetch = async (
         "Content-Type": "application/json",
     };
     if(authenticated) {
-        const token= localStorage.getItem("id_token");
+        const token = localStorage.getItem("access_token") || localStorage.getItem("id_token");
         if(token) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore

--- a/rococo-client/src/lib/api/authClient.ts
+++ b/rococo-client/src/lib/api/authClient.ts
@@ -13,19 +13,20 @@ export const authClient = {
         if (!response.ok) {
             throw new Error("Failed loading data");
         }
-        return response.json();
-    },
-    logout: async() => {
-        const response = await fetch(`${BASE_URL}/logout`, {
-            method: "GET",
-            credentials: "include",
-            headers: {
-                "Content-type": "application/json",
-                "Authorization": `Bearer ${localStorage.getItem("id_token")}`,
+        
+        const token = await response.json();
+        try {
+            if (token && typeof token === 'object') {
+                if (token.id_token) localStorage.setItem('id_token', token.id_token);
+                if (token.access_token) localStorage.setItem('access_token', token.access_token);
             }
-        });
-        if (!response.ok) {
-            throw new Error("Failed logout");
-        }
+        } catch (_) {}
+        return token;
+        
+    },
+    logout: async () => {
+        const response = await fetch(`${BASE_URL}/logout`, { method: "GET", credentials: "include" });
+        if (!response.ok) { throw new Error("Failed loading data"); }
+        try { localStorage.removeItem("id_token"); localStorage.removeItem("access_token"); } catch (_) {}
     }
 }

--- a/rococo-client/src/lib/helpers/apiClient.ts
+++ b/rococo-client/src/lib/helpers/apiClient.ts
@@ -159,7 +159,7 @@ const commonFetch = async (
         "Content-Type": "application/json",
     };
     if(authenticated) {
-        const token= localStorage.getItem("id_token");
+        const token = localStorage.getItem("access_token") || localStorage.getItem("id_token");
         if(token) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore

--- a/rococo-gateway/src/main/kotlin/guru/qa/rococo/controller/SessionController.kt
+++ b/rococo-gateway/src/main/kotlin/guru/qa/rococo/controller/SessionController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 data class SessionJson(
     val authenticated: Boolean,
-    val userName: String? = null
+    val username: String? = null
 )
 
 @RestController
@@ -21,10 +21,10 @@ class SessionController {
         // Откуда взять имя:
         // - OpenID ID Token часто кладёт preferred_username
         // - Иначе sub, а в крайнем случае subject
-        val userName = (jwt.getClaimAsString("preferred_username"))
+        val username = (jwt.getClaimAsString("preferred_username"))
             ?: jwt.getClaimAsString("sub")
             ?: jwt.subject
 
-        return SessionJson(authenticated = true, userName = userName)
+        return SessionJson(authenticated = true, username = username)
     }
 }

--- a/rococo-gateway/src/main/kotlin/guru/qa/rococo/controller/UserController.kt
+++ b/rococo-gateway/src/main/kotlin/guru/qa/rococo/controller/UserController.kt
@@ -1,0 +1,17 @@
+package guru.qa.rococo.controller
+
+import guru.qa.rococo.dto.UserJson
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UserController {
+    @GetMapping("/api/user")
+    fun me(@AuthenticationPrincipal jwt: Jwt): UserJson {
+        // возьми preferred_username если есть, иначе sub
+        val username = jwt.claims["preferred_username"] as? String ?: jwt.subject
+        return UserJson(username = username)
+    }
+}

--- a/rococo-gateway/src/main/kotlin/guru/qa/rococo/dto/UserJson.kt
+++ b/rococo-gateway/src/main/kotlin/guru/qa/rococo/dto/UserJson.kt
@@ -1,0 +1,3 @@
+package guru.qa.rococo.dto
+
+data class UserJson(val username: String)

--- a/rococo-gateway/src/main/resources/application.yml
+++ b/rococo-gateway/src/main/resources/application.yml
@@ -9,13 +9,17 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:9000
+          issuer-uri: http://127.0.0.1:9000
 
 gateway:
   cors:
     allowed-origins:
       - http://127.0.0.1:3000
 
+logging:
+  level:
+    org.springframework.security: DEBUG
+    org.springframework.security.oauth2: DEBUG
 #  graphql:
 #    graphiql:
 #      enabled: true


### PR DESCRIPTION
Починена авторизация после F5:

фронт теперь сохраняет access_token/id_token и подставляет Authorization: Bearer … во все защищённые запросы;

GET /api/session вызывается с токеном.

Унификация ответа gateway:

/api/session возвращает { authenticated, username } (раньше было userName) — фронт корректно определяет залогинен ли пользователь.

Небольшой рефакторинг:

apiClient.ts/api/apiClient.ts: чтение access_token || id_token, обработка 401 без потери сессии.

authClient.ts: сохранение токенов после обмена кода; очистка токенов на logout.